### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a JD Edwards connector"
 og:title: "Set up a JD Edwards connector"
-description: "C1 provides identity governance and just-in-time provisioning for Oracle's JD Edwards. Integrate your JD Edwards instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "C1 provides identity governance and just-in-time provisioning for Oracle's JD Edwards. Integrate your JD Edwards instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for JD Edwards. Integrate your JD Edwards instance with C1 for unified visibility and governance over user access."
+og:description: "C1 provides identity governance for JD Edwards. Integrate your JD Edwards instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "JD Edwards"
 ---
 
@@ -28,7 +28,7 @@ The URL of the AIS server.
 </Step>
 </Steps> 
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the JD Edwards connector
 
@@ -84,7 +84,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your JD Edwards connector is now pulling access data into C1.
+**Done.** Your JD Edwards connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -202,7 +202,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your JD Edwards connector is now pulling access data into C1.
+**Done.** Your JD Edwards connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines