### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -181,7 +181,7 @@ spec:
     spec:
       containers:
       - name: baton-jd-edwards
-        image: ghcr.io/conductorone/baton-jd-edwards:latest
+        image: public.ecr.aws/conductorone/baton-jd-edwards:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -205,7 +205,3 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 **Done.** Your JD Edwards connector is now pulling access data into C1.
 </Tab>
 </Tabs>
-
-
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._